### PR TITLE
Add Excel export JS bindings

### DIFF
--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -34,6 +34,14 @@ export function EditWarehouse(arg1:model.Warehouse):Promise<void>;
 
 export function ExportStockToExcel():Promise<string>;
 
+export function ExportUsersToExcel():Promise<string>;
+
+export function ExportSuppliersToExcel():Promise<string>;
+
+export function ExportDeliveriesToExcel():Promise<string>;
+
+export function ExportItemsToExcel():Promise<string>;
+
 export function FindItems(arg1:model.ItemFilter):Promise<Array<model.Item>>;
 
 export function FindStockByWarehouse(arg1:number):Promise<Array<model.ItemWithStock>>;

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -66,6 +66,22 @@ export function ExportStockToExcel() {
   return window['go']['app']['App']['ExportStockToExcel']();
 }
 
+export function ExportUsersToExcel() {
+  return window['go']['app']['App']['ExportUsersToExcel']();
+}
+
+export function ExportSuppliersToExcel() {
+  return window['go']['app']['App']['ExportSuppliersToExcel']();
+}
+
+export function ExportDeliveriesToExcel() {
+  return window['go']['app']['App']['ExportDeliveriesToExcel']();
+}
+
+export function ExportItemsToExcel() {
+  return window['go']['app']['App']['ExportItemsToExcel']();
+}
+
 export function FindItems(arg1) {
   return window['go']['app']['App']['FindItems'](arg1);
 }


### PR DESCRIPTION
## Summary
- expose all Excel export functions in `wailsjs`

## Testing
- `go vet ./...`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686265634958832ca0428e8a975651f0